### PR TITLE
Add jupyter-resource-usage to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -53,6 +53,7 @@ dependencies:
   - git
   - gh
   - code-server
+  - jupyter-resource-usage
   - jupyter-vscode-proxy
   # For visualizing results
   - hvplot


### PR DESCRIPTION
Adds [jupyter-server resource usage extension](https://github.com/jupyter-server/jupyter-resource-usage) that is also used in the pangeo notebook image (see https://github.com/pangeo-data/pangeo-docker-images/blob/master/pangeo-notebook/environment.yml#L63)

I don't think we have to explicitly enable the extension as described [here](https://github.com/jupyter-server/jupyter-resource-usage?tab=readme-ov-file#installation) because `jupyter-notebook --version` returns 7.2.2. So we will see if this works..